### PR TITLE
Hide location for CITY precision and enforce tenant admin permissions

### DIFF
--- a/src/api/v1/permissions.py
+++ b/src/api/v1/permissions.py
@@ -7,3 +7,14 @@ class IsOwnerOrAdmin(permissions.BasePermission):
             return True
         return obj.user == request.user
 
+
+class IsTenantAdmin(permissions.BasePermission):
+    """Allow access only to users belonging to TENANT_ADMIN group."""
+
+    def has_permission(self, request, view):
+        user = request.user
+        return bool(
+            user
+            and user.is_authenticated
+            and user.groups.filter(name="TENANT_ADMIN").exists()
+        )

--- a/src/api/v1/serializers.py
+++ b/src/api/v1/serializers.py
@@ -40,7 +40,8 @@ class EmployeeProfileSerializer(serializers.ModelSerializer):
         data = super().to_representation(instance)
         if not instance.visible:
             return {"id": instance.id}
-        if instance.precision == "HIDDEN" and "location" in data:
+        if instance.precision in {"HIDDEN", "CITY"} and "location" in data:
+            # Hide exact coordinates unless precision explicitly set to EXACT
             data.pop("location")
         return data
 

--- a/src/api/v1/views.py
+++ b/src/api/v1/views.py
@@ -20,7 +20,7 @@ from companies.models import Company
 from profiles.models import EmployeeProfile
 from tenancy.models import Domain, Tenant
 
-from .permissions import IsOwnerOrAdmin
+from .permissions import IsOwnerOrAdmin, IsTenantAdmin
 from .serializers import (
     CompanySerializer,
     EmployeeProfileSerializer,
@@ -137,14 +137,14 @@ class ProfileViewSet(viewsets.ModelViewSet):
 
 class CompanyView(generics.RetrieveUpdateAPIView):
     serializer_class = CompanySerializer
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsTenantAdmin]
 
     def get_object(self):
-        return Company.objects.first()
+        return Company.objects.get(tenant=self.request.tenant)
 
 
 class EmployeeImportAPIView(generics.GenericAPIView):
-    permission_classes = [permissions.IsAdminUser]
+    permission_classes = [IsTenantAdmin]
     parser_classes = [parsers.MultiPartParser]
 
     def post(self, request, *args, **kwargs):

--- a/src/companies/tests/test_company_view.py
+++ b/src/companies/tests/test_company_view.py
@@ -1,0 +1,46 @@
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accounts.models import User
+from companies.models import Company
+from tenancy.models import Tenant
+
+
+@pytest.mark.django_db
+def test_tenant_admin_can_update_company():
+    tenant = Tenant.objects.create(
+        schema_name="acme", name="Acme", domain_url="acme.local"
+    )
+    company = Company.objects.create(tenant=tenant, display_name="Old")
+    admin = User.objects.create_user(email="admin@example.com", password="pwd")
+    group, _ = Group.objects.get_or_create(name="TENANT_ADMIN")
+    admin.groups.add(group)
+    client = APIClient()
+    client.force_authenticate(user=admin)
+    url = reverse("api-v1:company")
+    resp = client.patch(
+        url, {"display_name": "New"}, format="json", HTTP_HOST=tenant.domain_url
+    )
+    assert resp.status_code == 200
+    company.refresh_from_db()
+    assert company.display_name == "New"
+
+
+@pytest.mark.django_db
+def test_regular_user_cannot_update_company():
+    tenant = Tenant.objects.create(
+        schema_name="acme", name="Acme", domain_url="acme.local"
+    )
+    company = Company.objects.create(tenant=tenant, display_name="Old")
+    user = User.objects.create_user(email="user@example.com", password="pwd")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("api-v1:company")
+    resp = client.patch(
+        url, {"display_name": "New"}, format="json", HTTP_HOST=tenant.domain_url
+    )
+    assert resp.status_code == 403
+    company.refresh_from_db()
+    assert company.display_name == "Old"

--- a/src/profiles/tests/test_precision.py
+++ b/src/profiles/tests/test_precision.py
@@ -1,0 +1,37 @@
+import pytest
+from django.contrib.gis.geos import Point
+
+from accounts.models import User
+from api.v1.serializers import EmployeeProfileSerializer
+from profiles.models import EmployeeProfile
+
+
+@pytest.mark.django_db
+def test_city_precision_hides_location():
+    user = User.objects.create_user(email="city@example.com", password="pwd")
+    profile = EmployeeProfile.objects.create(
+        user=user,
+        location=Point(1, 2),
+        city="NY",
+        country="US",
+        precision="CITY",
+    )
+    data = EmployeeProfileSerializer(profile).data
+    assert "location" not in data
+    assert data["city"] == "NY"
+    assert data["country"] == "US"
+
+
+@pytest.mark.django_db
+def test_exact_precision_keeps_location():
+    user = User.objects.create_user(email="exact@example.com", password="pwd")
+    profile = EmployeeProfile.objects.create(
+        user=user,
+        location=Point(3, 4),
+        city="NY",
+        country="US",
+        precision="EXACT",
+    )
+    data = EmployeeProfileSerializer(profile).data
+    assert "location" in data
+    assert data["location"] is not None


### PR DESCRIPTION
## Summary
- hide employee `location` when precision is CITY
- add `IsTenantAdmin` permission and use it for company and employee import views
- add tests for precision serialization and company update permissions

## Testing
- `pre-commit run --files src/api/v1/serializers.py src/api/v1/permissions.py src/api/v1/views.py src/profiles/tests/test_precision.py src/companies/tests/test_company_view.py`
- `PYTHONPATH=src pytest -q` *(fails: could not translate host name "db" to address)*


------
https://chatgpt.com/codex/tasks/task_b_68c559c683e8832ba59b730503941e4f