### PR TITLE
Add Spatialite test settings and expand API test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,20 @@ AWS_S3_REGION_NAME
 When developing locally files are stored under `media/` using the default
 Django file storage backend.
 
+## Testing
+
+Run the test suite using the lightweight SpatiaLite configuration:
+
+```bash
+pytest
+```
+
+This uses `config.settings.test` and requires no running PostgreSQL instance. To
+run tests against a real PostGIS database instead, start the containers and set
+the settings module:
+
+```bash
+make up
+DJANGO_SETTINGS_MODULE=config.settings.local pytest
+```
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = config.settings.local
+DJANGO_SETTINGS_MODULE = config.settings.test
 python_files = tests.py test_*.py *_tests.py
+pythonpath = src
 

--- a/src/accounts/tests/test_email_verification.py
+++ b/src/accounts/tests/test_email_verification.py
@@ -1,0 +1,24 @@
+import pytest
+from django.contrib.auth.tokens import default_token_generator
+from django.urls import reverse
+from django.utils.http import urlsafe_base64_encode
+from rest_framework.test import APIClient
+
+from accounts.models import User
+
+
+@pytest.mark.django_db
+def test_email_verification_marks_user_verified():
+    client = APIClient()
+    client.post(
+        reverse("api-v1:register"),
+        {"email": "verify@example.com", "password": "pwd"},
+        format="json",
+    )
+    user = User.objects.get(email="verify@example.com")
+    uid = urlsafe_base64_encode(str(user.pk).encode())
+    token = default_token_generator.make_token(user)
+    resp = client.get(reverse("api-v1:auth-verify"), {"uid": uid, "token": token})
+    assert resp.status_code == 200
+    user.refresh_from_db()
+    assert user.is_email_verified is True

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -71,7 +71,7 @@ DATABASES = {
 AUTH_USER_MODEL = "accounts.User"
 
 TENANT_MODEL = "tenancy.Tenant"
-TENANT_DOMAIN_MODEL = "tenancy.Tenant"
+TENANT_DOMAIN_MODEL = "tenancy.Domain"
 DATABASE_ROUTERS = ["django_tenants.routers.TenantSyncRouter"]
 
 REST_FRAMEWORK = {

--- a/src/config/settings/test.py
+++ b/src/config/settings/test.py
@@ -1,0 +1,40 @@
+from .base import *  # noqa: F401,F403
+from .base import BASE_DIR
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.contrib.gis.db.backends.spatialite",
+        "NAME": BASE_DIR / "test.sqlite3",
+    }
+}
+
+SPATIALITE_LIBRARY_PATH = env("SPATIALITE_LIBRARY_PATH", default="mod_spatialite")
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+# Simplify configuration for the lightweight spatialite test setup
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+]
+
+SHARED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "tenancy",
+    "accounts",
+]
+
+TENANT_APPS = ["profiles", "companies"]
+
+INSTALLED_APPS = ["django.contrib.admin"] + SHARED_APPS + TENANT_APPS
+
+DATABASE_ROUTERS = []
+TENANT_MODEL = "tenancy.Tenant"
+TENANT_DOMAIN_MODEL = "tenancy.Tenant"

--- a/src/config/settings/test.py
+++ b/src/config/settings/test.py
@@ -8,11 +8,15 @@ DATABASES = {
     }
 }
 
-SPATIALITE_LIBRARY_PATH = env("SPATIALITE_LIBRARY_PATH", default="mod_spatialite")
+SPATIALITE_LIBRARY_PATH = env(  # noqa: F405
+    "SPATIALITE_LIBRARY_PATH", default="mod_spatialite"
+)
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
-# Simplify configuration for the lightweight spatialite test setup
+INSTALLED_APPS = ["django.contrib.admin"] + SHARED_APPS + TENANT_APPS  # noqa: F405
+
 MIDDLEWARE = [
+    "django_tenants.middleware.main.TenantMainMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -21,20 +25,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
-SHARED_APPS = [
-    "django.contrib.contenttypes",
-    "django.contrib.auth",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    "tenancy",
-    "accounts",
-]
+DATABASE_ROUTERS = ["django_tenants.routers.TenantSyncRouter"]
 
-TENANT_APPS = ["profiles", "companies"]
-
-INSTALLED_APPS = ["django.contrib.admin"] + SHARED_APPS + TENANT_APPS
-
-DATABASE_ROUTERS = []
 TENANT_MODEL = "tenancy.Tenant"
-TENANT_DOMAIN_MODEL = "tenancy.Tenant"
+TENANT_DOMAIN_MODEL = "tenancy.Domain"

--- a/src/profiles/tests/test_csv_import.py
+++ b/src/profiles/tests/test_csv_import.py
@@ -1,0 +1,36 @@
+import pytest
+from django.contrib.auth.models import Group
+from django.core import mail
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accounts.models import User
+from profiles.models import EmployeeProfile
+
+
+@pytest.mark.django_db
+def test_csv_import_creates_users_profiles_and_sends_emails():
+    admin = User.objects.create_user(email="admin@example.com", password="pwd")
+    group, _ = Group.objects.get_or_create(name="TENANT_ADMIN")
+    admin.groups.add(group)
+    client = APIClient()
+    client.force_authenticate(user=admin)
+
+    csv_content = (
+        "email,title,city,country,lat,lon\n"
+        "u1@example.com,Dev,NY,US,0,0\n"
+        "u2@example.com,Mgr,,US,,\n"
+    )
+    upload = SimpleUploadedFile(
+        "employees.csv", csv_content.encode("utf-8"), content_type="text/csv"
+    )
+    resp = client.post(
+        reverse("api-v1:employees-import"), {"file": upload}, format="multipart"
+    )
+    assert resp.status_code == 200
+    assert User.objects.filter(email="u1@example.com").exists()
+    assert User.objects.filter(email="u2@example.com").exists()
+    assert EmployeeProfile.objects.filter(user__email="u1@example.com", city="NY").exists()
+    assert EmployeeProfile.objects.filter(user__email="u2@example.com").exists()
+    assert len(mail.outbox) == 2

--- a/src/profiles/tests/test_geosearch.py
+++ b/src/profiles/tests/test_geosearch.py
@@ -1,0 +1,34 @@
+import pytest
+from django.contrib.gis.geos import Point
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accounts.models import User
+from profiles.models import EmployeeProfile
+
+
+@pytest.mark.django_db
+def test_geosearch_returns_sorted_results_within_radius():
+    auth_user = User.objects.create_user(email="auth@example.com", password="pwd")
+    u1 = User.objects.create_user(email="p1@example.com", password="pwd")
+    u2 = User.objects.create_user(email="p2@example.com", password="pwd")
+    u3 = User.objects.create_user(email="p3@example.com", password="pwd")
+
+    p1 = EmployeeProfile.objects.create(
+        user=u1, location=Point(0, 0), precision="EXACT"
+    )
+    p2 = EmployeeProfile.objects.create(
+        user=u2, location=Point(1, 0), precision="EXACT"
+    )
+    EmployeeProfile.objects.create(
+        user=u3, location=Point(10, 0), precision="EXACT"
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=auth_user)
+    resp = client.get(
+        reverse("api-v1:profile-list"), {"near": "0,0", "radius_km": "200"}
+    )
+    assert resp.status_code == 200
+    ids = [item["id"] for item in resp.data]
+    assert ids == [p1.id, p2.id]


### PR DESCRIPTION
## Summary
- introduce Spatialite-based test settings and configure pytest to use them
- add tests for profile geosearch, CSV import, and email verification
- document how to run tests locally with Spatialite or with a PostGIS container

## Testing
- `pytest` *(fails: SpatiaLite requires SQLite to be configured to allow extension loading)*

------
https://chatgpt.com/codex/tasks/task_b_68c55ed03650832b88a54764e4fe6f15