### PR TITLE
Randomize city precision coordinates and update docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ ENV PYTHONUNBUFFERED 1
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY pyproject.toml /app/
 RUN pip install poetry && poetry config virtualenvs.create false && poetry install --no-root
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: format lint test up down migrate makemigrations
 
 format:
-black src
-isort src
+	black src
+	isort src
 
 lint:
 	flake8 src
 
 test:
-pytest --cov=src
+	pytest --cov=src
 
 up:
 	docker-compose up -d
@@ -21,4 +21,3 @@ migrate:
 
 makemigrations:
 	python manage.py makemigrations
-

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ the raw schema at `/api/schema/`.
 - `POST /api/v1/profiles/` – create or update your own profile including avatar
   upload. When an avatar is absent a gravatar URL is used.
 
+When a profile's location precision is set to `CITY`, the API returns a point
+randomly offset up to 5 km from the stored coordinates while keeping the `city`
+and `country` fields intact.
+
 ### Company
 
 - `GET/PUT /api/v1/company/` – retrieve or update company display name, logo and
@@ -65,18 +69,18 @@ Django file storage backend.
 
 ## Testing
 
-Run the test suite using the lightweight SpatiaLite configuration:
+Tests can run either against a PostGIS container or locally with SpatiaLite
+when the module is available.
+
+Run against PostGIS:
+
+```bash
+make up && pytest
+```
+
+Run locally with SpatiaLite:
 
 ```bash
 pytest
-```
-
-This uses `config.settings.test` and requires no running PostgreSQL instance. To
-run tests against a real PostGIS database instead, start the containers and set
-the settings module:
-
-```bash
-make up
-DJANGO_SETTINGS_MODULE=config.settings.local pytest
 ```
 

--- a/src/profiles/tests/test_precision.py
+++ b/src/profiles/tests/test_precision.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 from django.contrib.gis.geos import Point
 
@@ -6,20 +7,42 @@ from api.v1.serializers import EmployeeProfileSerializer
 from profiles.models import EmployeeProfile
 
 
+def haversine(a, b):
+    lat1, lon1 = a.y, a.x
+    lat2, lon2 = b.y, b.x
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    h = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(dlon / 2) ** 2
+    )
+    return 2 * 6371 * math.asin(math.sqrt(h))
+
+
 @pytest.mark.django_db
-def test_city_precision_hides_location():
+def test_city_precision_randomizes_location_within_radius():
     user = User.objects.create_user(email="city@example.com", password="pwd")
+    original = Point(1, 2)
     profile = EmployeeProfile.objects.create(
         user=user,
-        location=Point(1, 2),
+        location=original,
         city="NY",
         country="US",
         precision="CITY",
     )
-    data = EmployeeProfileSerializer(profile).data
-    assert "location" not in data
-    assert data["city"] == "NY"
-    assert data["country"] == "US"
+    data1 = EmployeeProfileSerializer(profile).data
+    data2 = EmployeeProfileSerializer(profile).data
+    assert "location" in data1
+    assert "location" in data2
+    p1 = Point(*data1["location"]["coordinates"])  # type: ignore[arg-type]
+    p2 = Point(*data2["location"]["coordinates"])  # type: ignore[arg-type]
+    assert p1 != original
+    assert p2 != original
+    assert p1 != p2
+    assert haversine(original, p1) <= 5
+    assert haversine(original, p2) <= 5
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- randomize location when profile precision is CITY
- document CITY precision and test execution options
- add geo dependencies to Dockerfile and fix Makefile tabs

## Testing
- `pytest` *(fails: AttributeError: 'DatabaseWrapper' object has no attribute 'set_schema')*

------
https://chatgpt.com/codex/tasks/task_b_68c56d693118832bb5744862ac75bc69